### PR TITLE
chore: springdoc-openapi 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 🎟️ Related Ticket: #11

## ✏️ Description
springdoc-openapi 의존성 추가

## 🧩 How
- build.gradle 파일에 dependency 추가
    ```dependencies {
        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
    }
    ```

## ⚠️ PR 참고 사항
- [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) 를 통해 Swagger API 문서 접근

## 📸 Screen Shot
<img width="857" alt="image" src="https://github.com/user-attachments/assets/9684f870-992d-487f-b342-1928defaeef7">


## ✅ Test Check
<!--테스트 진행 상황을 체크하세요.-->
- [ ] 테스트 작성 완료
- [x] 테스트 확인 완료

## Etc.
@jisong017 , @Kyeong6  확인 후 pull 부탁드려요!

[참고할만한 블로그](https://velog.io/@nefertiri/Spring-Swagger-%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-API-%EB%AA%85%EC%84%B8%EC%84%9C-%EC%9E%91%EC%84%B1-%EC%9E%90%EB%8F%99%ED%99%94%ED%95%98%EA%B8%B0) : Swagger API 작성
